### PR TITLE
feat: support multiple media per question

### DIFF
--- a/style.css
+++ b/style.css
@@ -1056,6 +1056,13 @@ h1, h2, h3 {
     margin: 0;
 }
 
+.question-media {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 8px 0;
+}
+
 .question-data img {
     max-width: 100%;
     height: auto;


### PR DESCRIPTION
## Summary
- add shared media helpers and sequential loaders so questions can render id-based galleries such as 2024-7-1.png and 2024-7-2.png
- update question rendering to mount media containers, attach fallback handling per image, and hide optional slots when assets are missing
- style grouped media blocks so stacked figures have consistent spacing

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e63ab3504c832198303cae5ed5b348