### PR TITLE
Handle optional question media gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -276,6 +276,8 @@ function initDashboard() {
             candidateSources.push(placeholderUrl);
         }
 
+        const hasExplicitMedia = !!(raw && !placeholderName);
+
         if (candidateSources.length) {
             const fallbacks = candidateSources.slice(1);
             if (placeholderUrl && !candidateSources.includes(placeholderUrl)) {
@@ -284,7 +286,8 @@ function initDashboard() {
             primaryEntry = {
                 initial: candidateSources[0],
                 fallbacks,
-                expectedNames: guidanceNames
+                expectedNames: guidanceNames,
+                optional: !hasExplicitMedia
             };
         }
 


### PR DESCRIPTION
## Summary
- mark heuristic question media entries as optional so missing assets no longer display warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64113dd1c8321a999e91fbb112778