### PR TITLE
Handle gaps when loading sequential question media

### DIFF
--- a/script.js
+++ b/script.js
@@ -379,7 +379,7 @@ function initDashboard() {
                 const uniqueSources = Array.from(new Set(sourceCandidates));
 
                 if (!uniqueSources.length) {
-                    finish();
+                    processIndex(index + 1);
                     return;
                 }
 
@@ -426,7 +426,7 @@ function initDashboard() {
                         return;
                     }
                     cleanup();
-                    finish();
+                    processIndex(index + 1);
                 };
 
                 tester.onload = handleSuccess;


### PR DESCRIPTION
## Summary
- update sequential media loading to continue searching when a numbered asset is missing
- ensure additional question attachments load even if earlier indices are absent

## Testing
- Not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_68e64518d11c8321976de3de07a4ec2d