### PR TITLE
Fix sequential media preloading for multi-image questions

### DIFF
--- a/script.js
+++ b/script.js
@@ -432,7 +432,6 @@ function initDashboard() {
                 tester.onload = handleSuccess;
                 tester.onerror = handleError;
                 tester.decoding = 'async';
-                tester.loading = 'lazy';
                 tester.src = uniqueSources[attempt];
             };
 


### PR DESCRIPTION
## Summary
- remove the lazy loading hint from the off-DOM probe image so sequential media files are actually requested
- verify that questions with multiple media assets (e.g. 2023-8) now render all associated images

## Testing
- browser_container.run_playwright_script (manual verification of multi-image question rendering)


------
https://chatgpt.com/codex/tasks/task_e_68e6477d029083219e124dae4389d8f8