### PR TITLE
Introduce media manifest for deterministic question media loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>소아과학 목차</title>
   <!-- 외부 CSS 불러오기 -->
-  <link rel="stylesheet" href="style.css?v=20241008" />
+  <link rel="stylesheet" href="style.css?v=20241009" />
 </head>
 <body>
   <main class="wrap">
@@ -70,6 +70,6 @@
   </main>
 
   <!-- 외부 JS 불러오기 -->
-  <script src="script.js?v=20241008"></script>
+  <script src="script.js?v=20241009"></script>
 </body>
 </html>

--- a/media_manifest.json
+++ b/media_manifest.json
@@ -1,0 +1,218 @@
+{
+  "hanbang": {
+    "2021-49": {
+      "primary": [
+        "2021-49.png"
+      ],
+      "sequential": []
+    },
+    "2021-56": {
+      "primary": [
+        "2021-56.png"
+      ],
+      "sequential": []
+    },
+    "2022-49": {
+      "primary": [
+        "2022-49.png"
+      ],
+      "sequential": []
+    },
+    "2022-50": {
+      "primary": [
+        "2022-50.png"
+      ],
+      "sequential": []
+    },
+    "2022-51": {
+      "primary": [
+        "2022-51.png"
+      ],
+      "sequential": []
+    },
+    "2022-59": {
+      "primary": [
+        "2022-59.png"
+      ],
+      "sequential": []
+    },
+    "2022-60": {
+      "primary": [
+        "2022-60.png"
+      ],
+      "sequential": []
+    },
+    "2023-51": {
+      "primary": [
+        "2023-51.png"
+      ],
+      "sequential": []
+    },
+    "2025-49": {
+      "primary": [
+        "2025-49.png"
+      ],
+      "sequential": []
+    },
+    "2025-52": {
+      "primary": [
+        "2025-52.png"
+      ],
+      "sequential": []
+    },
+    "2025-59": {
+      "primary": [
+        "2025-59.png"
+      ],
+      "sequential": []
+    },
+    "2025-60": {
+      "primary": [
+        "2025-60.png"
+      ],
+      "sequential": []
+    },
+    "2025-64": {
+      "primary": [
+        "2025-64.png"
+      ],
+      "sequential": []
+    }
+  },
+  "pedi": {
+    "2021-18": {
+      "primary": [
+        "2021-18.png"
+      ],
+      "sequential": []
+    },
+    "2021-7": {
+      "primary": [
+        "2021-7.png"
+      ],
+      "sequential": []
+    },
+    "2021-8": {
+      "primary": [
+        "2021-8.png"
+      ],
+      "sequential": []
+    },
+    "2022-19": {
+      "primary": [
+        "2022-19.png"
+      ],
+      "sequential": []
+    },
+    "2022-9": {
+      "primary": [
+        "2022-9.png"
+      ],
+      "sequential": []
+    },
+    "2023-2": {
+      "primary": [
+        "2023-2.png"
+      ],
+      "sequential": []
+    },
+    "2023-20": {
+      "primary": [
+        "2023-20.png"
+      ],
+      "sequential": []
+    },
+    "2023-24": {
+      "primary": [],
+      "sequential": [
+        "2023-24-1.png",
+        "2023-24-2.png"
+      ]
+    },
+    "2023-6": {
+      "primary": [
+        "2023-6.png"
+      ],
+      "sequential": []
+    },
+    "2023-8": {
+      "primary": [],
+      "sequential": [
+        "2023-8-1.png",
+        "2023-8-2.png"
+      ]
+    },
+    "2024-12": {
+      "primary": [
+        "2024-12.png"
+      ],
+      "sequential": []
+    },
+    "2024-2": {
+      "primary": [
+        "2024-2.png"
+      ],
+      "sequential": []
+    },
+    "2024-21": {
+      "primary": [
+        "2024-21.png"
+      ],
+      "sequential": []
+    },
+    "2024-23": {
+      "primary": [
+        "2024-23.png"
+      ],
+      "sequential": []
+    },
+    "2024-8": {
+      "primary": [
+        "2024-8.png"
+      ],
+      "sequential": []
+    },
+    "2024-9": {
+      "primary": [
+        "2024-9.png"
+      ],
+      "sequential": []
+    },
+    "2025-10": {
+      "primary": [
+        "2025-10.png"
+      ],
+      "sequential": []
+    },
+    "2025-11": {
+      "primary": [
+        "2025-11.png"
+      ],
+      "sequential": []
+    },
+    "2025-22": {
+      "primary": [
+        "2025-22.png"
+      ],
+      "sequential": []
+    },
+    "2025-7": {
+      "primary": [
+        "2025-7.png"
+      ],
+      "sequential": []
+    },
+    "2025-8": {
+      "primary": [
+        "2025-8.png"
+      ],
+      "sequential": []
+    },
+    "그림": {
+      "primary": [
+        "그림.svg"
+      ],
+      "sequential": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a static media_manifest.json enumerating available media assets per subject
- update the client to load the manifest, render sequential media in order, and avoid placeholder probes for missing files
- bump the asset cache-busting version in index.html so clients receive the updated script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6477d029083219e124dae4389d8f8